### PR TITLE
Add a link to si-scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ My aim is to eventually model this after the [JQuery Plugin site](https://github
 	
 - [The Museum System API](https://github.com/smoore4moma/TmsApi)
     - Services to access basic TMS tombstone and object package data.  Services are written in .NET, clients are jQuery.	
+
+- [si-scrape](https://github.com/mdlincoln/si-scrape)
+    - A set of Ruby scripts to scrape information from the Smithsonian Institution's collections portal, and parse it into machine-readable JSON.


### PR DESCRIPTION
A set of Ruby scripts to scrape information from the Smithsonian Institution's collections portal, and parse it into machine-readable JSON.
